### PR TITLE
doc: fix syntax for a couple of surfacer options

### DIFF
--- a/docs/content/docs/surfacers/overview.md
+++ b/docs/content/docs/surfacers/overview.md
@@ -145,7 +145,7 @@ backend monitoring system:
    surfacer {
       type: ...
 
-      add_failure_metric = true
+      add_failure_metric: true
       ..
    }
    ```
@@ -164,7 +164,7 @@ backend monitoring system:
    surfacer {
       type: ...
 
-      export_as_gauge = true
+      export_as_gauge: true
       ..
    }
    ```


### PR DESCRIPTION
Noticed that the surfacer doc showed a couple of options that did not match the `key: value` syntax as the rest of the doc. I tested this by setting these options exactly as I saw them in the doc, getting an error on the cloudprober pod upon startup, fixing the syntax, and watching the pod start up without fail.