### PR TITLE
doc: fix syntax for a couple of surfacer options

### DIFF
--- a/docs/content/docs/surfacers/overview.md
+++ b/docs/content/docs/surfacers/overview.md
@@ -145,7 +145,7 @@ backend monitoring system:
    surfacer {
       type: ...
 
-      add_failure_metric = true
+      add_failure_metric: true
       ..
    }
    ```
@@ -164,7 +164,7 @@ backend monitoring system:
    surfacer {
       type: ...
 
-      export_as_gauge = true
+      export_as_gauge: true
       ..
    }
    ```


### PR DESCRIPTION
Fixing syntax for a couple of surfacer options. I tested this by applying the options using the `key = value` syntax first and confirming the pod would not start. Then I changed to `key: value` and watched the pod start without fail.